### PR TITLE
iptables: Fix target TRACE issue

### DIFF
--- a/package/network/utils/iptables/Makefile
+++ b/package/network/utils/iptables/Makefile
@@ -207,6 +207,20 @@ define Package/iptables-mod-nflog/description
 
 endef
 
+define Package/iptables-mod-trace
+$(call Package/iptables/Module, +kmod-ipt-debug)
+  TITLE:=Netfilter TRACE target
+endef
+
+define Package/iptables-mod-trace/description
+ iptables extension for TRACE target
+
+ Includes:
+  - libxt_TRACE
+
+endef
+
+
 define Package/iptables-mod-nfqueue
 $(call Package/iptables/Module, +kmod-nfnetlink-queue +kmod-ipt-nfqueue)
   TITLE:=Netfilter NFQUEUE target
@@ -538,6 +552,7 @@ $(eval $(call BuildPlugin,iptables-mod-tproxy,$(IPT_TPROXY-m)))
 $(eval $(call BuildPlugin,iptables-mod-tee,$(IPT_TEE-m)))
 $(eval $(call BuildPlugin,iptables-mod-u32,$(IPT_U32-m)))
 $(eval $(call BuildPlugin,iptables-mod-nflog,$(IPT_NFLOG-m)))
+$(eval $(call BuildPlugin,iptables-mod-trace,$(IPT_DEBUG-m)))
 $(eval $(call BuildPlugin,iptables-mod-nfqueue,$(IPT_NFQUEUE-m)))
 $(eval $(call BuildPackage,ip6tables))
 $(eval $(call BuildPlugin,ip6tables-extra,$(IPT_IPV6_EXTRA-m)))


### PR DESCRIPTION
The package kmod-ipt-debug builds the module xt_TRACE, which allows
users to use '-j TRACE' as target in the chain PREROUTING of the table
raw in iptables.

The kernel compilation flag NETFILTER_XT_TARGET_TRACE is also enabled so
that this feature which is implemented deep inside the linux IP stack
(for example in sk_buff) is compiled.

But a strace of iptables -t raw -I PREROUTING -p icmp -j TRACE reveals
that an attempt is made to read /usr/lib/iptables/libxt_TRACE.so, which
fails as this dynamic library is not present on the system.

I created the package iptables-mod-trace which takes care of that, and
target TRACE now works!

https://dev.openwrt.org/ticket/16694
https://dev.openwrt.org/ticket/19661

Signed-off-by: Martin Wetterwald <martin.wetterwald@corp.ovh.com>